### PR TITLE
feat: implement Resource CRUD system from templates (v0.5.0-alpha)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 # Ignore key files for decrypting credentials and more.
 /config/*.key
 
+# Ignore git worktree directories.
+/.worktrees
+

--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -1,0 +1,72 @@
+class Api::ResourcesController < ApplicationController
+  include GameAuthenticatable
+  before_action :authenticate_user!
+  before_action :set_game
+  before_action :set_resource, only: [:show, :update, :destroy]
+  before_action :ensure_owner_or_gm!, only: [:update, :destroy]
+
+  def index
+    @resources = @game.resources.active
+    render json: @resources, status: :ok
+  end
+
+  def show
+    render json: @resource, status: :ok
+  end
+
+  def create
+    @template = @game.resource_templates.active.find(params[:resource_template_id])
+
+    result = ResourceFromTemplateBuilder.call(
+      template: @template,
+      current_user: current_user,
+      params: resource_params
+    )
+
+    if result.success?
+      if result.resource.save
+        render json: result.resource, status: :created
+      else
+        render json: { errors: result.resource.errors.full_messages }, status: :unprocessable_content
+      end
+    else
+      render json: { error: result.error }, status: result.status
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Resource template not found" }, status: :not_found
+  end
+
+  def update
+    if @resource.update(resource_params)
+      render json: @resource, status: :ok
+    else
+      render json: { errors: @resource.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  def destroy
+    if @resource.update(archived_at: Time.current)
+      render json: { message: "Resource archived successfully", archived_at: @resource.archived_at }, status: :ok
+    else
+      render json: { errors: ["Could not archive resource"] }, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def set_resource
+    @resource = @game.resources.active.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Resource not found" }, status: :not_found
+  end
+
+  def ensure_owner_or_gm!
+    unless @resource.player == current_user || @game.gm?(current_user)
+      render json: { error: "Forbidden" }, status: :forbidden
+    end
+  end
+
+  def resource_params
+    params.require(:resource).permit(:name, :player_id, data: {})
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,6 +3,7 @@ class Game < ApplicationRecord
   has_many :users, through: :game_memberships
 
   has_many :resource_templates, dependent: :destroy
+  has_many :resources, dependent: :destroy
 
   validates :title, presence: true
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -4,4 +4,6 @@ class Resource < ApplicationRecord
   belongs_to :player, class_name: "User", optional: true
 
   validates :name, presence: true
+
+  scope :active, -> { where(archived_at: nil) }
 end

--- a/app/models/resource_template.rb
+++ b/app/models/resource_template.rb
@@ -5,6 +5,7 @@ class ResourceTemplate < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: :game_id }
   validates :template_type, inclusion: { in: %w[character item status npc custom] }
+  validates :creatable_by, inclusion: { in: %w[gm all] }
 
   validate :validate_schema_structure
 

--- a/app/services/resource_from_template_builder.rb
+++ b/app/services/resource_from_template_builder.rb
@@ -1,0 +1,62 @@
+class ResourceFromTemplateBuilder
+  Result = Struct.new(:success?, :resource, :error, :status, keyword_init: true)
+
+  def self.call(template:, current_user:, params:)
+    new(template:, current_user:, params:).call
+  end
+
+  def initialize(template:, current_user:, params:)
+    @template = template
+    @current_user = current_user
+    @params = params
+  end
+
+  def call
+    return forbidden_result unless authorized?
+
+    resource = Resource.new(
+      resource_template: @template,
+      game: @template.game,
+      name: @params[:name],
+      data: merged_data,
+      player: assigned_player
+    )
+
+    Result.new(success?: true, resource: resource)
+  end
+
+  private
+
+  def authorized?
+    return true if @template.creatable_by == "all"
+    return false if @template.creatable_by != "gm"
+
+    @template.game.gm?(@current_user)
+  end
+
+  def forbidden_result
+    Result.new(
+      success?: false,
+      error: "You are not authorized to create resources from this template",
+      status: :forbidden
+    )
+  end
+
+  def merged_data
+    defaults = {}
+    fields = @template.schema&.dig("fields") || []
+    fields.each do |field|
+      defaults[field["field_key"]] = nil
+    end
+    provided = @params[:data] || {}
+    defaults.deep_merge(provided)
+  end
+
+  def assigned_player
+    if @params[:player_id].present? && @template.game.gm?(@current_user)
+      User.find_by(id: @params[:player_id])
+    else
+      @current_user
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :games do
-      resources :resource_templates
+      resources :resource_templates do
+        resources :resources, only: [:create]
+      end
+      resources :resources, only: [:index, :show, :update, :destroy]
     end
   end
 end

--- a/db/migrate/20260531161953_add_creatable_by_to_resource_templates.rb
+++ b/db/migrate/20260531161953_add_creatable_by_to_resource_templates.rb
@@ -1,0 +1,5 @@
+class AddCreatableByToResourceTemplates < ActiveRecord::Migration[8.1]
+  def change
+    add_column :resource_templates, :creatable_by, :string, default: "gm", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_161544) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_31_161953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -37,6 +37,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_161544) do
 
   create_table "resource_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "archived_at"
+    t.string "creatable_by", default: "gm", null: false
     t.datetime "created_at", null: false
     t.uuid "game_id", null: false
     t.string "name", null: false

--- a/docs/progress/2026-06-01.md
+++ b/docs/progress/2026-06-01.md
@@ -84,7 +84,6 @@
 
 | Date                                          | Status                                      |
 | :-------------------------------------------- | :------------------------------------------ |
-| [June 1, 2026](docs/progress/2026-06-01.md)   | 🔵 Resource System Complete                 |
 | [March 31, 2026](docs/progress/2026-03-31.md) | 🔵 Games CRUD & Authorization Complete      |
 | [March 22, 2026](docs/progress/2026-03-22.md) | 🔵 Authentication & Identity Layer Complete |
 | [March 20, 2026](docs/progress/2026-03-20.md) | 🟢 Data Layer Foundation Complete           |

--- a/docs/superpowers/plans/2026-06-01-resource-system.md
+++ b/docs/superpowers/plans/2026-06-01-resource-system.md
@@ -1,0 +1,36 @@
+# Resource System Implementation Plan
+
+**Date:** 2026-06-01
+**Target Version:** 0.5.0-alpha
+
+## Tasks
+
+### Task 1: Migration — Add `creatable_by` to ResourceTemplate
+- Generate migration: `AddCreatableByToResourceTemplates`
+- Add string column `creatable_by` with default `"gm"`, not null
+- Run migration
+- Update schema.rb
+
+### Task 2: Model Changes
+- **ResourceTemplate**: Add `validates :creatable_by, inclusion: { in: %w[gm all] }`
+- **Resource**: Add `scope :active, -> { where(archived_at: nil) }`, validate name presence, association specs
+
+### Task 3: Routes
+- Add nested resources routes under games for index/show/update/destroy
+- Add nested resources routes under resource_templates for create only
+
+### Task 4: Builder Service
+- Create `app/services/resource_from_template_builder.rb` with:
+  - Permission check (creatable_by + gm check)
+  - Data defaults from template schema fields
+  - Player assignment (defaults to current_user, GM override)
+  - Returns Result struct with success?/resource/error/status
+
+### Task 5: Controller + Request Specs
+- Create `app/controllers/api/resources_controller.rb`
+- Create `spec/requests/api/resources_spec.rb` (~20 specs)
+- Create `spec/services/resource_from_template_builder_spec.rb` (~5 specs)
+- Update `spec/models/resource_spec.rb` with validation specs
+
+### Task 6: Progress Update
+- Update PROGRESS.md to 0.5.0-alpha

--- a/docs/superpowers/specs/2026-06-01-resource-system-design.md
+++ b/docs/superpowers/specs/2026-06-01-resource-system-design.md
@@ -1,0 +1,115 @@
+# Resource System Design
+
+**Date:** 2026-06-01
+**Status:** Design (pre-implementation)
+**Version:** 0.5.0-alpha target
+
+## Overview
+
+Add a Resource controller and service layer to instantiate resources from resource templates. A Resource is a concrete game entity (character, item, etc.) created from a template's schema definition.
+
+## Routes
+
+```ruby
+namespace :api do
+  resources :games do
+    resources :resource_templates do
+      resources :resources, only: [:create]
+    end
+    resources :resources, only: [:index, :show, :update, :destroy]
+  end
+end
+```
+
+- **Create** (`POST /api/games/:game_id/resource_templates/:template_id/resources`) — creation requires a template
+- **Index** (`GET /api/games/:game_id/resources`) — game-scoped listing
+- **Show / Update / Destroy** — member routes under the game
+
+## Model Changes
+
+### ResourceTemplate — add `creatable_by`
+
+New column `creatable_by` (string, default `"gm"`, not null) with inclusion validation on `%w[gm all]`.
+
+Values:
+- `"gm"` — only GMs can create resources from this template
+- `"all"` — any game member can create resources from this template
+
+### Resource — no schema validation (deferred)
+
+The `data` JSONB field is not validated against the template schema at the model level. The builder handles data structure on creation; clients are responsible for well-formed data on updates.
+
+## ResourceFromTemplateBuilder
+
+A plain Ruby service object at `app/services/resource_from_template_builder.rb`:
+
+```ruby
+class ResourceFromTemplateBuilder
+  def self.call(template:, current_user:, params:)
+    # Returns a Result struct with:
+    #   success? — boolean
+    #   resource — unsaved Resource instance (nil on failure)
+    #   error    — string message (nil on success)
+    #   status   — symbol for HTTP status (:forbidden, :unprocessable_content)
+  end
+end
+```
+
+Behaviors:
+- **Permission check:** If `template.creatable_by == "gm"` and current_user is not a GM, return `Result.new(success: false, error: "...", status: :forbidden)`.
+- **Data defaults:** For each field in `template.schema["fields"]`, set `{ field_key => nil }`. Deep-merge any `params[:data]` over top.
+- **Player assignment:** Defaults to `current_user.id`. If a `player_id` param is present and current_user is GM, use that instead.
+- **Success return:** On successful build, return `Result.new(success: true, resource: resource)`. The resource is not yet saved — the controller calls `resource.save`.
+
+## Controller — Api::ResourcesController
+
+Follows the same pattern as `Api::ResourceTemplatesController`.
+
+| Action | Auth | Notes |
+|--------|------|-------|
+| `index` | All active game members | `@game.resources.active` |
+| `show` | All active game members | Scoped to game, 404 if not found |
+| `create` | Per template's `creatable_by` | Uses builder, returns 201/422 |
+| `update` | GM or owning player | 403 otherwise |
+| `destroy` | GM or owning player | Soft-delete via `archived_at` |
+
+Reuses `GameAuthenticatable` concern (`set_game`, `ensure_gm!`) plus a new check:
+
+```ruby
+def ensure_owner_or_gm!
+  resource = @game.resources.active.find(params[:id])
+  unless resource.player == current_user || @game.gm?(current_user)
+    render json: { error: "Forbidden" }, status: :forbidden
+  end
+end
+```
+
+## Testing
+
+### Request specs (`spec/requests/api/resources_spec.rb`)
+
+- Create: player with `creatable_by: "all"` succeeds / with `"gm"` gets 403 / GM with `"gm"` succeeds
+- Create: invalid data returns 422
+- Index: game member sees all resources / non-member gets 404
+- Show: member sees resource / non-member gets 404 / archived returns 404
+- Update: GM updates any / owning player updates own / non-owning player gets 403
+- Destroy: GM archives any / owning player archives own / non-owning player gets 403
+
+### Service specs (`spec/services/resource_from_template_builder_spec.rb`)
+
+- Pre-populates data from schema fields with nil defaults
+- Merges client-provided data over the defaults
+- Rejects creation when `creatable_by == "gm"` and user is player
+- Sets `player_id` to current_user by default
+- Sets `player_id` to provided value when GM overrides
+
+### Model specs — add to `spec/models/resource_spec.rb`
+
+- Validates name presence
+- Associations (belongs to template, game, player)
+
+## Future Considerations
+
+- **Secret fields:** If a field in the template schema gains a `secret: true` flag, resource data for those fields should be filtered per-player (only the owning player and GM see them).
+- **Data validation on update:** Optionally validate that `data` keys match the template schema on future edits.
+- **Serializer layer:** Once Jbuilder/jbuild is introduced, include `data` fields dynamically based on the template schema.

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :game do
-    title { Faker::Books::CultureSeries.unique.book }
+    title { Faker::Books::CultureSeries.book }
     description { Faker::Lorem.paragraph }
 
     system { "5e" }

--- a/spec/factories/resource_templates.rb
+++ b/spec/factories/resource_templates.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :resource_template do
     association :game
-    name { Faker::Books::CultureSeries.unique.book }
+    name { Faker::Books::CultureSeries.book }
     template_type { "character" }
     schema {
       {

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     game
     name { "MyString" }
     data { {} }
+
+    after(:build) do |resource|
+      if resource.resource_template.game != resource.game
+        resource.resource_template.game = resource.game
+      end
+    end
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,20 +1,50 @@
 require 'rails_helper'
 
 RSpec.describe Resource, type: :model do
-  describe 'validations' do
-    it 'is invalid without a name' do
-      resource = described_class.new(name: nil)
+  describe 'associations' do
+    it 'belongs to a resource_template' do
+      association = described_class.reflect_on_association(:resource_template)
+      expect(association.macro).to eq(:belongs_to)
+    end
 
-      expect(resource).not_to be_valid
-      expect(resource.errors[:name]).to be_present
+    it 'belongs to a game' do
+      association = described_class.reflect_on_association(:game)
+      expect(association.macro).to eq(:belongs_to)
+    end
+
+    it 'belongs to a player (optional)' do
+      association = described_class.reflect_on_association(:player)
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.options[:optional]).to be(true)
     end
   end
 
-  describe 'associations' do
-    it 'defines belongs_to associations for resource_template, game, and player' do
-      belongs_to_names = described_class.reflect_on_all_associations(:belongs_to).map(&:name)
+  describe 'validations' do
+    it 'is valid with a name' do
+      resource = build(:resource, name: "Gandalf")
+      expect(resource).to be_valid
+    end
 
-      expect(belongs_to_names).to include(:resource_template, :game, :player)
+    it 'is invalid without a name' do
+      resource = build(:resource, name: nil)
+      expect(resource).not_to be_valid
+      expect(resource.errors[:name]).to include("can't be blank")
+    end
+  end
+
+  describe 'scopes' do
+    let!(:game) { create(:game) }
+    let!(:gm) { create(:user) }
+    let!(:active_resource) { create(:resource, game: game) }
+    let!(:archived_resource) { create(:resource, game: game, archived_at: 1.day.ago) }
+
+    before do
+      create(:game_membership, user: gm, game: game, role: :gm)
+    end
+
+    it 'returns only active (non-archived) resources' do
+      expect(described_class.active).to include(active_resource)
+      expect(described_class.active).not_to include(archived_resource)
     end
   end
 end

--- a/spec/models/resource_template_spec.rb
+++ b/spec/models/resource_template_spec.rb
@@ -54,5 +54,21 @@ RSpec.describe ResourceTemplate, type: :model do
       expect(template.errors[:schema]).to include("field at index 0 is missing 'field_key'")
       expect(template.errors[:schema]).to include("field at index 1 is missing 'input_type'")
     end
+
+    it "is valid with a valid creatable_by value" do
+      template = ResourceTemplate.new(game: game, name: "Template", template_type: "character", schema: valid_schema, creatable_by: "all")
+      expect(template).to be_valid
+    end
+
+    it "is invalid with an unsupported creatable_by value" do
+      template = ResourceTemplate.new(game: game, name: "Template", template_type: "character", schema: valid_schema, creatable_by: "nobody")
+      expect(template).not_to be_valid
+      expect(template.errors[:creatable_by]).to include("is not included in the list")
+    end
+
+    it "defaults creatable_by to 'gm'" do
+      template = ResourceTemplate.new(game: game, name: "Template", template_type: "character", schema: valid_schema)
+      expect(template.creatable_by).to eq("gm")
+    end
   end
 end

--- a/spec/requests/api/resources_spec.rb
+++ b/spec/requests/api/resources_spec.rb
@@ -1,0 +1,205 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Resources", type: :request do
+  let!(:gm) { create(:user) }
+  let!(:player) { create(:user) }
+  let!(:other_player) { create(:user) }
+  let(:gm_headers) { auth_headers(gm) }
+  let(:player_headers) { auth_headers(player) }
+  let(:other_player_headers) { auth_headers(other_player) }
+  let(:game) { create(:game) }
+
+  let!(:template) do
+    create(:resource_template, game: game, schema: {
+      "fields" => [
+        { "field_key" => "name", "label" => "Name", "input_type" => "text" },
+        { "field_key" => "hp", "label" => "HP", "input_type" => "number" }
+      ]
+    })
+  end
+
+  let(:valid_create_params) do
+    {
+      resource: {
+        name: "Gandalf",
+        data: { "name" => "Gandalf", "hp" => 100 }
+      }
+    }
+  end
+
+  before do
+    create(:game_membership, user: gm, game: game, role: :gm)
+    create(:game_membership, user: player, game: game, role: :player)
+    create(:game_membership, user: other_player, game: game, role: :player)
+  end
+
+  describe "POST /api/games/:game_id/resource_templates/:template_id/resources" do
+    context "when creatable_by is 'gm'" do
+      before { template.update!(creatable_by: "gm") }
+
+      it "creates a resource for a GM" do
+        expect {
+          post "/api/games/#{game.id}/resource_templates/#{template.id}/resources",
+               params: valid_create_params, headers: gm_headers, as: :json
+        }.to change(Resource, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(json["name"]).to eq("Gandalf")
+        expect(json["data"]["hp"]).to eq(100)
+      end
+
+      it "rejects a player" do
+        expect {
+          post "/api/games/#{game.id}/resource_templates/#{template.id}/resources",
+               params: valid_create_params, headers: player_headers, as: :json
+        }.not_to change(Resource, :count)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when creatable_by is 'all'" do
+      before { template.update!(creatable_by: "all") }
+
+      it "creates a resource for a player" do
+        expect {
+          post "/api/games/#{game.id}/resource_templates/#{template.id}/resources",
+               params: valid_create_params, headers: player_headers, as: :json
+        }.to change(Resource, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "with invalid data" do
+      it "returns 422 when name is missing" do
+        post "/api/games/#{game.id}/resource_templates/#{template.id}/resources",
+             params: { resource: { name: "", data: {} } },
+             headers: gm_headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(json["errors"]).to include("Name can't be blank")
+      end
+    end
+  end
+
+  describe "GET /api/games/:game_id/resources" do
+    let!(:resource1) { create(:resource, game: game, name: "Aragorn", player: player) }
+    let!(:resource2) { create(:resource, game: game, name: "Legolas", player: other_player) }
+    let!(:archived_resource) { create(:resource, game: game, name: "Archived", archived_at: 1.day.ago) }
+    let!(:other_game_resource) { create(:resource, name: "Sauron") }
+
+    it "returns all active resources for the game" do
+      get "/api/games/#{game.id}/resources", headers: player_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json.size).to eq(2)
+      expect(json.map { |r| r["name"] }).to include("Aragorn", "Legolas")
+    end
+
+    it "returns 404 for non-member" do
+      non_member = create(:user)
+      non_member_headers = auth_headers(non_member)
+
+      get "/api/games/#{game.id}/resources", headers: non_member_headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET /api/games/:game_id/resources/:id" do
+    let!(:resource) { create(:resource, game: game, name: "Gandalf", player: player) }
+
+    it "returns the resource for a game member" do
+      get "/api/games/#{game.id}/resources/#{resource.id}", headers: player_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json["name"]).to eq("Gandalf")
+    end
+
+    it "returns 404 for non-member" do
+      non_member = create(:user)
+      non_member_headers = auth_headers(non_member)
+
+      get "/api/games/#{game.id}/resources/#{resource.id}", headers: non_member_headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns 404 for archived resource" do
+      archived = create(:resource, game: game, archived_at: 1.day.ago)
+
+      get "/api/games/#{game.id}/resources/#{archived.id}", headers: player_headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /api/games/:game_id/resources/:id" do
+    let!(:resource) { create(:resource, game: game, name: "Gandalf", player: player) }
+
+    context "when GM updates" do
+      it "updates the resource" do
+        patch "/api/games/#{game.id}/resources/#{resource.id}",
+              params: { resource: { name: "Gandalf the White" } },
+              headers: gm_headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json["name"]).to eq("Gandalf the White")
+      end
+    end
+
+    context "when owning player updates" do
+      it "updates the resource" do
+        patch "/api/games/#{game.id}/resources/#{resource.id}",
+              params: { resource: { name: "Gandalf the Grey" } },
+              headers: player_headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json["name"]).to eq("Gandalf the Grey")
+      end
+    end
+
+    context "when non-owning player updates" do
+      it "returns 403" do
+        patch "/api/games/#{game.id}/resources/#{resource.id}",
+              params: { resource: { name: "Gandalf the White" } },
+              headers: other_player_headers, as: :json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/games/:game_id/resources/:id" do
+    let!(:resource) { create(:resource, game: game, name: "Gandalf", player: player) }
+
+    context "when GM archives" do
+      it "soft-deletes the resource" do
+        delete "/api/games/#{game.id}/resources/#{resource.id}", headers: gm_headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json["message"]).to eq("Resource archived successfully")
+        expect(resource.reload.archived_at).not_to be_nil
+      end
+    end
+
+    context "when owning player archives" do
+      it "soft-deletes the resource" do
+        delete "/api/games/#{game.id}/resources/#{resource.id}", headers: player_headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(resource.reload.archived_at).not_to be_nil
+      end
+    end
+
+    context "when non-owning player archives" do
+      it "returns 403" do
+        delete "/api/games/#{game.id}/resources/#{resource.id}", headers: other_player_headers, as: :json
+
+        expect(response).to have_http_status(:forbidden)
+        expect(resource.reload.archived_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/resource_from_template_builder_spec.rb
+++ b/spec/services/resource_from_template_builder_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe ResourceFromTemplateBuilder, type: :service do
+  describe '.call' do
+    let!(:game) { create(:game) }
+    let!(:gm) { create(:user) }
+    let!(:player) { create(:user) }
+    let!(:template) do
+      create(:resource_template, game: game, schema: {
+        "fields" => [
+          { "field_key" => "name", "label" => "Name", "input_type" => "text" },
+          { "field_key" => "hp", "label" => "Hit Points", "input_type" => "number" },
+          { "field_key" => "is_ally", "label" => "Is Ally", "input_type" => "checkbox" }
+        ]
+      })
+    end
+
+    before do
+      create(:game_membership, user: gm, game: game, role: :gm)
+      create(:game_membership, user: player, game: game, role: :player)
+    end
+
+    context 'when creatable_by is "gm"' do
+      before { template.update!(creatable_by: "gm") }
+
+      it 'allows GM to create a resource' do
+        result = described_class.call(template: template, current_user: gm, params: {})
+        expect(result).to be_success
+        expect(result.resource).to be_a(Resource)
+        expect(result.resource).not_to be_persisted
+      end
+
+      it 'rejects a non-GM player' do
+        result = described_class.call(template: template, current_user: player, params: {})
+        expect(result).not_to be_success
+        expect(result.status).to eq(:forbidden)
+        expect(result.error).to be_present
+      end
+    end
+
+    context 'when creatable_by is "all"' do
+      before { template.update!(creatable_by: "all") }
+
+      it 'allows a player to create a resource' do
+        result = described_class.call(template: template, current_user: player, params: {})
+        expect(result).to be_success
+        expect(result.resource).to be_a(Resource)
+      end
+
+      it 'allows a GM to create a resource' do
+        result = described_class.call(template: template, current_user: gm, params: {})
+        expect(result).to be_success
+      end
+    end
+
+    describe 'data defaults' do
+      it 'pre-populates data from schema fields with nil defaults' do
+        result = described_class.call(template: template, current_user: gm, params: {})
+        expect(result.resource.data).to eq({ "name" => nil, "hp" => nil, "is_ally" => nil })
+      end
+
+      it 'merges client-provided data over the defaults' do
+        result = described_class.call(
+          template: template,
+          current_user: gm,
+          params: { data: { "name" => "Gandalf", "hp" => 100 } }
+        )
+        expect(result.resource.data["name"]).to eq("Gandalf")
+        expect(result.resource.data["hp"]).to eq(100)
+        expect(result.resource.data["is_ally"]).to be_nil
+      end
+    end
+
+    describe 'player assignment' do
+      before { template.update!(creatable_by: "all") }
+
+      it 'defaults player_id to current_user' do
+        result = described_class.call(template: template, current_user: player, params: {})
+        expect(result.resource.player).to eq(player)
+      end
+
+      it 'allows GM to override player_id' do
+        other_user = create(:user)
+        create(:game_membership, user: other_user, game: game, role: :player)
+        result = described_class.call(
+          template: template,
+          current_user: gm,
+          params: { player_id: other_user.id }
+        )
+        expect(result.resource.player).to eq(other_user)
+      end
+
+      it 'ignores player_id override from non-GM' do
+        other_user = create(:user)
+        result = described_class.call(
+          template: template,
+          current_user: player,
+          params: { player_id: other_user.id }
+        )
+        expect(result.resource.player).to eq(player)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to instantiate concrete game entities (Resources) from ResourceTemplate schemas.

Changes:
- Add creatable_by column to ResourceTemplate (default: gm, validates gm/all)
- Add ResourcesController with full CRUD (index/show/create/update/destroy)
- Add ResourceFromTemplateBuilder service with permission checks, data defaults, and player assignment
- Add active scope to Resource model for soft-delete filtering
- Add has_many :resources to Game model
- Add 32 new specs (model, service, request) — 80 total, all passing
- Archive PROGRESS.md to docs/progress/2026-06-01.md

Authorization:
- Create respects template's creatable_by (gm-only or all members)
- Index/Show: any game member
- Update/Destroy: GM or owning player only
- Player_id defaults to current_user, overridable by GM